### PR TITLE
enable bitcode instead of marker

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,7 @@ cmake -G Xcode
   - set `Build Active Architectures Only` to `NO`
   - set `Deployment Target` to the base iOS version to support
   - set `Inline Methods Hidden` and `Symbols Hidden by Default` to `YES`
+  - click the '+' to add a `User-Defined Setting` with the name `BITCODE_GENERATION_MODE` and the value `bitcode`
 
 #### 4. Build avrocpp_s for iOS simulator and Device targets
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -25,12 +25,11 @@ cmake -G Xcode
   - set `Build Active Architectures Only` to `NO`
   - set `Deployment Target` to the base iOS version to support
   - set `Inline Methods Hidden` and `Symbols Hidden by Default` to `YES`
-  - click the '+' to add a `User-Defined Setting` with the name `BITCODE_GENERATION_MODE` and the value `bitcode`
 
 #### 4. Build avrocpp_s for iOS simulator and Device targets
 ```
-xcodebuild -target avrocpp_s -config RelWithDebInfo -sdk iphoneos
-xcodebuild -target avrocpp_s -config RelWithDebInfo -sdk iphonesimulator
+xcodebuild BITCODE_GENERATION_MODE=bitcode -target avrocpp_s -config RelWithDebInfo -sdk iphoneos
+xcodebuild BITCODE_GENERATION_MODE=bitcode -target avrocpp_s -config RelWithDebInfo -sdk iphonesimulator
 ```
 
 #### 5. Lipo those suckers


### PR DESCRIPTION
By default xcodebuild will generate `bitcode-marker` data, which is not helpful when distributing libraries (it's meant only for debugging)

This manifests itself when an app is being 'archived', at which point Xcode kicks in bitcode generation for real, and we started to see errors.

This addresses the problem by specifying `BITCODE_GENERATION_MODE` explicitly

http://stackoverflow.com/a/34965178/204209
