### PR TITLE
MCC-226902 update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ DerivedData
 
 # untar'd dir
 avro-cpp-1.7.7/
+
+# Unzipped prebuilts
+prebuilt/ios/*.a


### PR DESCRIPTION
This PR updates the .gitignore to include the unzipped prebuilts, so that we don't see our submodules in our `git status` output.
